### PR TITLE
Update QCG documentation

### DIFF
--- a/_data/qcg.yml
+++ b/_data/qcg.yml
@@ -73,6 +73,12 @@ qcggrow:
       No fixing of the solute during the grow process 
       (fixing is only applied for water as solvent file).
 
+  - cmd: --normdock
+    descript: >
+      Use the docking algorithm during the grow algorithm with normal settings
+      (per default, reduced settings are applied for a faster search).
+      This is only possible in combination with the aISS algorithm.
+
 
 qcgensemble:
 


### PR DESCRIPTION
Adding the `--normdock flag that allows the use of the aISS algorithm with normal settings. Currently, only reduced settings can be applied for a faster search.